### PR TITLE
Arreglar package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "NewMakerBot",
+  "name": "newmakerbot",
+  "private": true,
   "version": "1.0.0",
   "description": "Telegram bot for launching welcome to new user at MakersUPV group",
-  "main": "index.js",
+  "main": "newmakerbot.js",
   "author": {
     "name": "Jaime",
     "email": "jaimelaborda@gmail.com"
   },
   "scripts": {
-    "start": "node index.js"
+    "start": "node newmakerbot.js"
   },
   "license": "GPL-3.0",
   "repository": {
@@ -16,10 +17,6 @@
     "url": "https://github.com/makers-upv/newmakerbot"
   },
   "dependencies": {
-    "geolib": "^2.0.24",
-    "get-json": "1.0.0",
-    "node-emoji": "^1.8.1",
-    "telegraf": "^3.16.0",
-    "telegraf-recast": "^2.1.0"
+    "telegraf": "^3.16.0"
   }
 }


### PR DESCRIPTION
- No se permiten nombres de paquetes con mayúsculas
- Hacer privado para no publicar sin darse cuenta
- Señalar el archivo correcto como `main`
- Quitar dependencias innecesarias