### PR TITLE
Añadir dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/newmakerbot.js
+++ b/newmakerbot.js
@@ -7,8 +7,9 @@ bienvenida.
 Creación y matenimiento: Jaime Laborda - jaimelaborda@gmail.com
 ----------------------------------------------------------------------------*/
 
+require("dotenv").config();
 const Telegraf = require("telegraf");
-const token = "BotFather_token_goes_here";
+const token = process.env.TELEGRAM_BOT_TOKEN;
 const bot = new Telegraf(token);
 
 bot.command("testbot", ctx => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,11 @@
         "ms": "^2.1.1"
       }
     },
+    "dotenv": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.1.0.tgz",
+      "integrity": "sha512-/veDn2ztgRlB7gKmE3i9f6CmDIyXAy6d5nBq+whO9SLX+Zs1sXEgFLPi+aSuWqUuusMfbi84fT8j34fs1HaYUw=="
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "start": "node newmakerbot.js"
   },
   "dependencies": {
-    "telegraf": "^3.16.0"
+    "telegraf": "^3.16.0",
+    "dotenv":"^6.1.0"
   }
 }

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,1 @@
+TELEGRAM_BOT_TOKEN=BotFather_token_goes_here


### PR DESCRIPTION
Para añadir el token de Telegram, copia el archivo `sample.env` y llama a la copia `.env`.
Rellena ahí el `TELEGRAM_BOT_TOKEN`.